### PR TITLE
Fix: the message body text is not displayed correctly in light themes (as “normal”)

### DIFF
--- a/notify.scm
+++ b/notify.scm
@@ -260,12 +260,12 @@
 
     (define border-style (get-style notification))
 
-    (define block (make-block (theme->bg *helix.cx*) border-style "all" "rounded"))
+    (define block (make-block (theme-scope *helix.cx* "ui.background") border-style "all" "rounded"))
     (buffer/clear frame outer-area)
     (block/render frame outer-area block)
 
     (define header-area (area inner-area-x (+ inner-area-y 1) inner-width 1))
-    (define header-line (make-block (theme->bg *helix.cx*) border-style "top" "plain"))
+    (define header-line (make-block (theme-scope *helix.cx* "ui.background") border-style "top" "plain"))
     (block/render frame header-area header-line)
 
     (render-lines frame (+ inner-area-x 1) inner-area-y notification (bg-style notification))

--- a/notify.scm
+++ b/notify.scm
@@ -74,7 +74,7 @@
 (define (bg-style notification)
   (if (unbox (Notification-blink notification))
       (begin (set-box! (Notification-blink notification) #f) (theme-scope *helix.cx* "ui.selection"))
-      (theme-scope *helix.cx* "normal")))
+      (theme-scope *helix.cx* "ui.text")))
 
 (define (find pred lst)
   (cond ((null? lst) #f)
@@ -274,7 +274,7 @@
 
 ;; A helper over `frame-set-string!` to render a list of lines, one list member per line
 (define (render-lines frame start-x start-y notification bg-style)
-  (define normal-style (theme-scope *helix.cx* "normal"))
+  (define normal-style (theme-scope *helix.cx* "ui.text"))
 
   (unless (minimal-render? notification)
           (frame-set-string! frame start-x start-y (get-header notification) (get-style notification))


### PR DESCRIPTION
Fix [issue #2](https://github.com/chuwy/notify.hx/issues/2)

[Use "ui.text" instead of "normal"](https://github.com/mattwparas/helix/blob/8a3347b42f0e18108ff838430de810858e9b5df2/helix-term/src/commands/engine/steel/components.rs#L135)

[theme->bg is deprecated](https://github.com/mattwparas/helix/blob/8a3347b42f0e18108ff838430de810858e9b5df2/helix-term/src/commands/engine/steel/components.scm#L13)